### PR TITLE
fix wrong get started link redirection to docs

### DIFF
--- a/src/components/footer/data.ts
+++ b/src/components/footer/data.ts
@@ -30,7 +30,7 @@ const resources = {
     {
       name: "Docs",
       image: "/svg/Docs.svg",
-      url: "https://docs.litmuschaos.io/docs/getstarted/",
+      url: "https://docs.litmuschaos.io/docs/getting-started/installation/",
     },
     {
       name: "FAQ",

--- a/src/components/nav/Burger.tsx
+++ b/src/components/nav/Burger.tsx
@@ -106,7 +106,7 @@ const Burger: React.FC = () => {
               <a
                 rel="noopener noreferrer"
                 target="_blank"
-                href="https://docs.litmuschaos.io/docs/getstarted/"
+                href="https://docs.litmuschaos.io/docs/getting-started/installation/"
                 className="buttonMobile"
               >
                 Get Started

--- a/src/components/pre-footer/PreFooterTop.tsx
+++ b/src/components/pre-footer/PreFooterTop.tsx
@@ -60,7 +60,7 @@ const PreFooterTop: React.FC = () => {
               <a
                 rel="noopener noreferrer"
                 target="_blank"
-                href="https://docs.litmuschaos.io/docs/getstarted/"
+                href="https://docs.litmuschaos.io/docs/getting-started/installation/"
               >
                 <Button gradientColor="purple">Get started with Litmus</Button>
               </a>

--- a/src/components/sections/community/Head.tsx
+++ b/src/components/sections/community/Head.tsx
@@ -35,7 +35,7 @@ const HeaderContent: React.FC = () => {
       <a
         rel="noopener noreferrer"
         target="_blank"
-        href="https://docs.litmuschaos.io/docs/getstarted/"
+        href="https://docs.litmuschaos.io/docs/getting-started/installation/"
       >
         <Button gradientColor="purple">Get Started</Button>
       </a>

--- a/src/components/sections/home/Head.tsx
+++ b/src/components/sections/home/Head.tsx
@@ -126,7 +126,7 @@ const HeadText: React.FC = () => {
     <Button
       gradientColor="purple"
       onClick={() =>
-        window.open("https://docs.litmuschaos.io/docs/getstarted/")
+        window.open("https://docs.litmuschaos.io/docs/getting-started/installation/")
       }
     >
       Get Started

--- a/src/components/sections/whylitmus/Head.tsx
+++ b/src/components/sections/whylitmus/Head.tsx
@@ -27,7 +27,7 @@ const HeaderContent: React.FC = () => {
       <a
         rel="noopener noreferrer"
         target="_blank"
-        href="https://docs.litmuschaos.io/docs/getstarted/"
+        href="https://docs.litmuschaos.io/docs/getting-started/installation/"
       >
         <Button gradientColor="purple">Get Started</Button>
       </a>


### PR DESCRIPTION
fixes issue #174 to redirect to the new docs getting started link: https://docs.litmuschaos.io/docs/getting-started/installation/